### PR TITLE
Add repository monitor.

### DIFF
--- a/Subversion/InedoExtension/InedoExtension.csproj
+++ b/Subversion/InedoExtension/InedoExtension.csproj
@@ -31,27 +31,27 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Inedo.Agents.Client, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.4\lib\net452\Inedo.Agents.Client.dll</HintPath>
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.Agents.Client.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Inedo.ExecutionEngine, Version=64.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.4\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
+    <Reference Include="Inedo.ExecutionEngine, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Inedo.SDK, Version=1.0.4.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.4\lib\net452\Inedo.SDK.dll</HintPath>
+    <Reference Include="Inedo.SDK, Version=1.1.2.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Inedo.SDK.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="InedoLib, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.4\lib\net452\InedoLib.dll</HintPath>
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\InedoLib.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.SDK.1.0.4\lib\net452\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.1.2\lib\net452\Newtonsoft.Json.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -76,6 +76,8 @@
     <Compile Include="Operations\SvnUpdateOperation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemoteMethods.cs" />
+    <Compile Include="RepositoryMonitors\SvnRepositoryCommit.cs" />
+    <Compile Include="RepositoryMonitors\SvnRepositoryMonitor.cs" />
     <Compile Include="SuggestionProviders\SvnPathBrowser.cs" />
     <Compile Include="SvnArgumentBuilder.cs" />
     <Compile Include="VariableFunctions\SvnDefaultServerNameVariableFunction.cs" />

--- a/Subversion/InedoExtension/RepositoryMonitors/SvnRepositoryCommit.cs
+++ b/Subversion/InedoExtension/RepositoryMonitors/SvnRepositoryCommit.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Inedo.ExecutionEngine;
+using Inedo.Extensibility.RepositoryMonitors;
+using Inedo.Serialization;
+
+namespace Inedo.Extensions.Subversion.RepositoryMonitors
+{
+    [Serializable]
+    internal sealed class SvnRepositoryCommit : RepositoryCommit
+    {
+        [Persistent]
+        public string Revision { get; set; }
+
+        public override bool Equals(RepositoryCommit other)
+        {
+            if (!(other is SvnRepositoryCommit svnCommit))
+                return false;
+
+            return string.Equals(this.Revision, svnCommit.Revision, StringComparison.OrdinalIgnoreCase);
+        }
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(this.Revision);
+
+        public override string GetFriendlyDescription() => this.ToString();
+
+        public override string ToString() => this.Revision ?? string.Empty;
+
+        public override IReadOnlyDictionary<RuntimeVariableName, RuntimeValue> GetRuntimeVariables()
+        {
+            return new Dictionary<RuntimeVariableName, RuntimeValue>()
+            {
+                [new RuntimeVariableName("RevisionNumber", RuntimeValueType.Scalar)] = this.Revision
+            };
+        }
+    }
+}

--- a/Subversion/InedoExtension/RepositoryMonitors/SvnRepositoryMonitor.cs
+++ b/Subversion/InedoExtension/RepositoryMonitors/SvnRepositoryMonitor.cs
@@ -1,0 +1,71 @@
+﻿using Inedo.Documentation;
+using Inedo.Extensibility;
+using Inedo.Extensibility.Credentials;
+using Inedo.Extensibility.RepositoryMonitors;
+using Inedo.Extensions.Subversion.Credentials;
+using Inedo.Serialization;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Security;
+using System.Threading.Tasks;
+
+namespace Inedo.Extensions.Subversion.RepositoryMonitors
+{
+    [DisplayName("Subversion")]
+    [Description("Monitors a Subversion repository for new commits.")]
+    public sealed class SvnRepositoryMonitor : RepositoryMonitor, IHasCredentials<SubversionCredentials>
+    {
+        [Persistent]
+        [DisplayName("Credentials")]
+        [Category("Connection/Identity")]
+        public string CredentialName { get; set; }
+
+        [Persistent]
+        [Category("Connection")]
+        [ScriptAlias("RepositoryUrl")]
+        [DisplayName("Repository URL")]
+        [PlaceholderText("Use repository URL from credentials")]
+        [MappedCredential(nameof(SubversionCredentials.RepositoryUrl))]
+        public string RepositoryUrl { get; set; }
+        [Persistent]
+        [Category("Connection")]
+        [ScriptAlias("UserName")]
+        [DisplayName("User name")]
+        [PlaceholderText("Use user name from credentials")]
+        [MappedCredential(nameof(SubversionCredentials.UserName))]
+        public string UserName { get; set; }
+        [Persistent(Encrypted = true)]
+        [Category("Connection")]
+        [ScriptAlias("Password")]
+        [DisplayName("Password")]
+        [PlaceholderText("Use password from credentials")]
+        [MappedCredential(nameof(SubversionCredentials.Password))]
+        public SecureString Password { get; set; }
+        [Persistent]
+        [Category("Connection")]
+        [ScriptAlias("SvnExePath")]
+        [DisplayName("svn.exe path")]
+        [DefaultValue("$SvnExePath")]
+        public string SvnExePath { get; set; }
+
+        public override async Task<IReadOnlyDictionary<string, RepositoryCommit>> GetCurrentCommitsAsync(IRepositoryMonitorContext context)
+        {
+            var client = new SvnClient(this.UserName, this.Password, context.Agent, this.SvnExePath, this, context.CancellationToken);
+            var branches = await client.EnumerateBranchesAsync(new SvnPath(this.RepositoryUrl, string.Empty));
+
+            var results = new Dictionary<string, RepositoryCommit>();
+            foreach (var b in branches)
+                results[b.Path.RepositoryRelativePath.Trim('/')] = new SvnRepositoryCommit { Revision = b.Revision };
+
+            return results;
+        }
+
+        public override RichDescription GetDescription()
+        {
+            return new RichDescription(
+                "Subversion repository at ",
+                new Hilite(AH.CoalesceString(this.RepositoryUrl, this.CredentialName))
+            );
+        }
+    }
+}

--- a/Subversion/InedoExtension/packages.config
+++ b/Subversion/InedoExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Inedo.SDK" version="1.0.4" targetFramework="net452" />
+  <package id="Inedo.SDK" version="1.1.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This monitors the latest revision of the `trunk` directory and all directories under `branches/`.

Provides a single variable, `$RevisionNumber`.

If some other group of directories is preferred, the code can be changed to take the directory list as a setting.

Fixes #3.